### PR TITLE
Fix riscv's TLS implementation

### DIFF
--- a/libc/bionic/bionic_elf_tls.cpp
+++ b/libc/bionic/bionic_elf_tls.cpp
@@ -139,11 +139,15 @@ size_t StaticTlsLayout::reserve_exe_segment_and_tcb(const TlsSegment* exe_segmen
 
 #elif __riscv_xlen == 64
 
-  const size_t exe_size = round_up_with_overflow_check(exe_segment->size, exe_segment->alignment);
-  reserve(exe_size, 1);
-  const size_t max_align = MAX(alignof(bionic_tcb), exe_segment->alignment);
-  offset_bionic_tcb_ = reserve(sizeof(bionic_tcb), max_align);
-  return offset_bionic_tcb_ - exe_size;
+  // FIXME: Align TCB block and EXE's segment more accurate. For current implementation,
+  // alignment requirement is not considered carefully.
+
+  // Reserve bionic tcb 
+  offset_bionic_tcb_ = reserve(sizeof(bionic_tcb), 1);
+
+  // The RISCV ELF TLS ABI specifies that thread pointer point to the end of TCB
+  const size_t result = reserve(exe_segment->size, exe_segment->alignment);
+  return result;
 
 #else
 #error "Unrecognized architecture"

--- a/libc/platform/bionic/tls_defines.h
+++ b/libc/platform/bionic/tls_defines.h
@@ -96,19 +96,23 @@
 
 #elif __riscv_xlen == 64
 
-#define MIN_TLS_SLOT              0
+// The RISCV ELF TLS ABI specifies that the thread pointer points at the end of TCB
+// So the negative index here to represent that the TCB is placed before what thread 
+// pointer points
 
-#define TLS_SLOT_SELF             0
-#define TLS_SLOT_THREAD_ID        1
-#define TLS_SLOT_APP              2 // was historically used for errno
-#define TLS_SLOT_OPENGL           3
-#define TLS_SLOT_OPENGL_API       4
-#define TLS_SLOT_STACK_GUARD      5
-#define TLS_SLOT_SANITIZER        6 // was historically used for dlerror
-#define TLS_SLOT_ART_THREAD_SELF  7
-#define TLS_SLOT_DTV              8
-#define TLS_SLOT_BIONIC_TLS       9
-#define MAX_TLS_SLOT              9 // update this value when reserving a slot
+#define MIN_TLS_SLOT             (-9) // update this value when reserving a slot
+#define TLS_SLOT_BIONIC_TLS      (-9)
+#define TLS_SLOT_DTV             (-8)
+#define TLS_SLOT_THREAD_ID       (-7)
+#define TLS_SLOT_APP             (-6) // was historically used for errno
+#define TLS_SLOT_OPENGL          (-5)
+#define TLS_SLOT_OPENGL_API      (-4)
+#define TLS_SLOT_STACK_GUARD     (-3)
+#define TLS_SLOT_SANITIZER       (-2) // was historically used for dlerror
+#define TLS_SLOT_ART_THREAD_SELF (-1)
+
+// The maximum slot is fixed by the minimum TLS alignment in Bionic executables.
+#define MAX_TLS_SLOT             (-1)
 
 #elif defined(__i386__) || defined(__x86_64__)
 


### PR DESCRIPTION
Fix bionic's tcb TLS slot index and the process of reserve exe segment
and bionic_tcb.

Currently, the alignment was not considered carefully when reserve exe
segment and bionic_tcb.