### PR TITLE
riscv64: fix `fenv` handling

### DIFF
--- a/libm/riscv64/fenv.c
+++ b/libm/riscv64/fenv.c
@@ -46,7 +46,7 @@ int fesetenv(const fenv_t* envp)
 
   __get_fcw(env);
   if (*envp != env)
-	__set_fcw(env);
+    __set_fcw(*envp);
   return 0;
 }
 
@@ -119,7 +119,7 @@ int feupdateenv(const fenv_t* envp)
 
 int feenableexcept(int mask __unused)
 {
-  return 0;
+  return -1;
 }
 
 int fedisableexcept(int mask __unused)

--- a/tests/fenv_test.cpp
+++ b/tests/fenv_test.cpp
@@ -181,7 +181,7 @@ TEST(fenv, fedisableexcept_fegetexcept) {
 }
 
 TEST(fenv, feenableexcept_fegetexcept) {
-#if defined(__aarch64__) || defined(__arm__)
+#if defined(__aarch64__) || defined(__arm__) || (defined(__riscv) && (__riscv_xlen == 64))
   // ARM doesn't support this. They used to if you go back far enough, but it was removed in
   // the Cortex-A8 between r3p1 and r3p2.
   ASSERT_EQ(-1, feenableexcept(FE_INVALID));
@@ -194,8 +194,10 @@ TEST(fenv, feenableexcept_fegetexcept) {
   ASSERT_EQ(0, fegetexcept());
   ASSERT_EQ(-1, feenableexcept(FE_INEXACT));
   ASSERT_EQ(0, fegetexcept());
+#ifndef __riscv
   ASSERT_EQ(-1, feenableexcept(FE_DENORMAL));
   ASSERT_EQ(0, fegetexcept());
+#endif
 #else
   // We can't recover from SIGFPE, so sacrifice a child...
   pid_t pid = fork();


### PR DESCRIPTION
This pull request fixes several issues with `fenv` handling and should close https://github.com/aosp-riscv/working-group/issues/39.

### Issues with `fesetenv`

There was a typo in `fesetenv` that prevented the `fcsr` to be set correctly. The typo has been corrected.

### Issues with `fesetexcept`

`fesetexcept` should return `-1` when the architecture does not support masking FPU exception vectors.

### Issues with `tests/fenv_test.cpp`

Since RISC-V is a RISC architecture, it should be tested like other RISC architecture: `fesetexcept` should return `-1` (indicates the platforms does not support it), and `fegetexcept` should always return `0`.