### PR TITLE
libm/riscv64: add partial hard-float support to libm

### DIFF
--- a/libm/Android.bp
+++ b/libm/Android.bp
@@ -347,6 +347,16 @@ cc_library {
         riscv64: {
             srcs: [
                 "riscv64/fenv.c",
+                "riscv64/lrint.S",
+                "riscv64/rint.S",
+            ],
+            exclude_srcs: [
+                "upstream-freebsd/lib/msun/src/s_llrint.c",
+                "upstream-freebsd/lib/msun/src/s_llrintf.c",
+                "upstream-freebsd/lib/msun/src/s_lrint.c",
+                "upstream-freebsd/lib/msun/src/s_lrintf.c",
+                "upstream-freebsd/lib/msun/src/s_rint.c",
+                "upstream-freebsd/lib/msun/src/s_rintf.c",
             ],
             version_script: ":libm.riscv64.map",
         },

--- a/libm/riscv64/lrint.S
+++ b/libm/riscv64/lrint.S
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <private/bionic_asm.h>
+
+ENTRY(lrint)
+  FCVT.L.D a0, fa0, dyn
+  RET
+END(lrint)
+
+ENTRY(lrintf)
+  FCVT.L.S a0, fa0, dyn
+  RET
+END(lrintf)
+
+// sizeof(long) and sizeof(long long) are the same for riscv64
+ALIAS_SYMBOL(llrint, lrint);
+ALIAS_SYMBOL(llrintf, lrintf);
+
+NOTE_GNU_PROPERTY()

--- a/libm/riscv64/rint.S
+++ b/libm/riscv64/rint.S
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <private/bionic_asm.h>
+
+ENTRY(rint)
+  FCVT.L.D a0, fa0, dyn
+  FCVT.D.L ft0, a0, dyn
+  FSGNJ.D  fa0, ft0, fa0
+  RET
+END(rint)
+
+ENTRY(rintf)
+  FCVT.W.S a0, fa0, dyn
+  FCVT.S.W ft0, a0, dyn
+  FSGNJ.S  fa0, ft0, fa0
+  RET
+END(rintf)
+
+NOTE_GNU_PROPERTY()


### PR DESCRIPTION
Now, `riscv64` target correctly supports `rint` and `lrint` rounding for `float` and `double` (`long double` is currently unsupported).

A detailed analysis is available at https://liushuyu.xyz/riscv-aosp-bionic-1/. If you can't view this URL, you can navigate to https://github.com/liushuyu/articles/blob/master/content/riscv-aosp-bionic-1.md instead.

A Chinese version is also provided at https://liushuyu.xyz/zh/riscv-aosp-bionic-1/.

------

```c
# define __get_fcw(cw) __asm__ volatile ("frcsr %0" : "=r" (cw))
# define __set_fcw(cw) __asm__ volatile ("fscsr %z0" : : "r" (cw))
```

~~This segment replaces the older naming convention with the newer ones specified in RISC-V ISA standard manual, version 20191213.~~ Removed per request.