### PR TITLE
libm/riscv64: minor bugfixes in `fenv`

### DIFF
--- a/libm/riscv64/fenv.c
+++ b/libm/riscv64/fenv.c
@@ -29,8 +29,8 @@
 #include <stdint.h>
 #include <fenv.h>
 
-# define __get_fcw(cw) __asm__ volatile ("frsr %0" : "=r" (cw))
-# define __set_fcw(cw) __asm__ volatile ("fssr %z0" : : "r" (cw))
+# define __get_fcw(cw) __asm__ volatile ("frcsr %0" : "=r" (cw))
+# define __set_fcw(cw) __asm__ volatile ("fscsr %z0" : : "r" (cw))
 
 const fenv_t __fe_dfl_env = 0;
 
@@ -95,7 +95,6 @@ int fegetround(void)
 
 int fesetround(int round)
 {
-  round &= FE_UPWARD;
   asm volatile ("fsrm %z0" : : "r" (round));
   return 0;
 }


### PR DESCRIPTION
This pull request does the following:

1. Renamed several instructions to the newer naming convention.
2. Removed the extra rounding mode filtering in `fesetround` since filtering is probably only needed in full soft-float implementations.