### PR TITLE
libm/riscv64: detect invalid rounding mode in `fesetround`

### DIFF
--- a/libm/riscv64/fenv.c
+++ b/libm/riscv64/fenv.c
@@ -95,6 +95,12 @@ int fegetround(void)
 
 int fesetround(int round)
 {
+  /* Check whether requested rounding direction is supported
+   * Currently, we deem FE_TONEAREST_MM (RMM) as invalid
+   * should any usecase for that arise, we can simply change the mask */
+  if (round < FE_TONEAREST || round > FE_UPWARD) {
+    return -1;
+  }
   asm volatile ("fsrm %z0" : : "r" (round));
   return 0;
 }


### PR DESCRIPTION
This pull request adds a detection to `fesetround` so that invalid rounding mode will be rejected.